### PR TITLE
Add resource limits, healthcheck, and fix Swarm deploy config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,15 +6,32 @@ services:
     environment:
       - FLASK_ENV=production
       - PORT=5000
-    restart: unless-stopped
     networks:
       - drunk-net
-    deploy: 
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:5000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    deploy:
       mode: replicated
       replicas: 1
       placement:
         constraints:
           - node.role != manager
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+      update_config:
+        order: start-first
+        parallelism: 1
+      resources:
+        limits:
+          memory: 512M
+          cpus: "0.50"
+        reservations:
+          memory: 256M
 
 networks:
   drunk-net:


### PR DESCRIPTION
- Replace restart: unless-stopped with Swarm-compatible deploy.restart_policy
- Add 512M/256M memory limits/reservations and 0.5 CPU
- Add healthcheck against /health endpoint
- Add update_config for rolling updates